### PR TITLE
Small update

### DIFF
--- a/Autonomix.uplugin
+++ b/Autonomix.uplugin
@@ -63,7 +63,7 @@
 		{
 			"Name": "AutonomixActions",
 			"Type": "Editor",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PostEngineInit"
 		}
 	]
 }

--- a/Source/AutonomixActions/Private/Blueprint/AutonomixBlueprintActions.cpp
+++ b/Source/AutonomixActions/Private/Blueprint/AutonomixBlueprintActions.cpp
@@ -1336,6 +1336,13 @@ FAutonomixActionResult FAutonomixBlueprintActions::ExecuteInjectNodesT3D(const T
 		return Result;
 	}
 
+	// Validate T3D format
+	if (!T3DText.StartsWith(TEXT("Begin Object")))
+	{
+		Result.Errors.Add(TEXT("T3D injection failed: T3D string must begin with 'Begin Object'"));
+		return Result;
+	}
+
 	FString GraphName = TEXT("EventGraph");
 	Params->TryGetStringField(TEXT("graph_name"), GraphName);
 
@@ -1396,11 +1403,14 @@ FAutonomixActionResult FAutonomixBlueprintActions::ExecuteInjectNodesT3D(const T
 	{
 		// ImportNodesFromText produces a silent failure on malformed T3D
 		Result.Errors.Add(FString::Printf(
-			TEXT("T3D injection produced 0 nodes in graph '%s'. Possible causes: malformed T3D syntax, wrong Class= specifier, missing 'Begin Object'/'End Object' wrapper, or node Class not available. "
+			TEXT("T3D injection failed: ImportNodesFromText returned 0 nodes in graph '%s'. Possible causes: malformed T3D syntax, wrong Class= specifier, missing 'Begin Object'/'End Object' wrapper, or node Class not available. "
 				 "Verify T3D format: each block must start with 'Begin Object Class=/Script/BlueprintGraph.K2Node_XXX Name=\"NodeName\"' and end with 'End Object'."),
 			*GraphName));
 		return Result;
 	}
+
+	// Mark blueprint as modified
+	FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
 
 	Blueprint->Modify();
 

--- a/Source/AutonomixLLM/Private/AutonomixOpenAICompatClient.cpp
+++ b/Source/AutonomixLLM/Private/AutonomixOpenAICompatClient.cpp
@@ -13,6 +13,7 @@
 // ==========================================================================
 // Call ID sanitization for OpenAI Responses API
 // Ported from Roo Code utils/tool-id.ts sanitizeOpenAiCallId()
+// Force rebuild after token counter removal
 // ==========================================================================
 
 /** Sanitize a tool call ID to match OpenAI's validation pattern: ^[a-zA-Z0-9_-]+$
@@ -193,30 +194,6 @@ void FAutonomixOpenAICompatClient::SendMessage(
 	RetrySystemPrompt = SystemPrompt;
 	RetryToolSchemas = ToolSchemas;
 
-	// ---- Token budget enforcement ----
-	// Estimate total request tokens and truncate history if necessary to fit context window.
-	// Prevents 400 errors from oversized payloads (Issue #3: 400k+ token usage).
-	int32 ContextWindow = FAutonomixTokenCounter::GetContextWindowTokens();
-	int32 SystemTokens = FAutonomixTokenCounter::EstimateTokens(SystemPrompt);
-	int32 ToolTokens = FAutonomixTokenCounter::EstimateTokens(ToolSchemas);
-	int32 OverheadTokens = 1000; // JSON structure, metadata, etc.
-	TArray<FAutonomixMessage> EffectiveHistory = ConversationHistory;
-	int32 HistoryTokens = FAutonomixTokenCounter::EstimateTokens(EffectiveHistory);
-	int32 TotalTokens = SystemTokens + HistoryTokens + ToolTokens + OverheadTokens;
-
-	if (TotalTokens > ContextWindow)
-	{
-		UE_LOG(LogAutonomix, Warning, TEXT("OpenAICompatClient: Estimated total tokens %d exceeds context window %d. Truncating history."), TotalTokens, ContextWindow);
-		// Truncate history from the beginning until it fits
-		while (EffectiveHistory.Num() > 1 && TotalTokens > ContextWindow)
-		{
-			EffectiveHistory.RemoveAt(0);
-			HistoryTokens = FAutonomixTokenCounter::EstimateTokens(EffectiveHistory);
-			TotalTokens = SystemTokens + HistoryTokens + ToolTokens + OverheadTokens;
-		}
-		UE_LOG(LogAutonomix, Log, TEXT("OpenAICompatClient: After truncation, history has %d messages, total tokens %d."), EffectiveHistory.Num(), TotalTokens);
-	}
-
 	// ---- API type selection ----
 	// Responses API (/v1/responses): official OpenAI only (GPT-5.x, GPT-4.1, o-series).
 	// Azure, Ollama, LMStudio, Custom do NOT support the Responses API.
@@ -227,7 +204,7 @@ void FAutonomixOpenAICompatClient::SendMessage(
 	                               Provider == EAutonomixProvider::Custom);
 	bUseResponsesAPI = (Provider == EAutonomixProvider::OpenAI) && !bIsAzureRequest && !bIsLocalProvider;
 
-	TSharedPtr<FJsonObject> Body = BuildRequestBody(EffectiveHistory, SystemPrompt, ToolSchemas);
+	TSharedPtr<FJsonObject> Body = BuildRequestBody(ConversationHistory, SystemPrompt, ToolSchemas);
 	FString BodyString;
 	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&BodyString);
 	FJsonSerializer::Serialize(Body.ToSharedRef(), Writer);

--- a/Source/AutonomixLLM/Private/AutonomixOpenAICompatClient.cpp
+++ b/Source/AutonomixLLM/Private/AutonomixOpenAICompatClient.cpp
@@ -193,6 +193,30 @@ void FAutonomixOpenAICompatClient::SendMessage(
 	RetrySystemPrompt = SystemPrompt;
 	RetryToolSchemas = ToolSchemas;
 
+	// ---- Token budget enforcement ----
+	// Estimate total request tokens and truncate history if necessary to fit context window.
+	// Prevents 400 errors from oversized payloads (Issue #3: 400k+ token usage).
+	int32 ContextWindow = FAutonomixTokenCounter::GetContextWindowTokens();
+	int32 SystemTokens = FAutonomixTokenCounter::EstimateTokens(SystemPrompt);
+	int32 ToolTokens = FAutonomixTokenCounter::EstimateTokens(ToolSchemas);
+	int32 OverheadTokens = 1000; // JSON structure, metadata, etc.
+	TArray<FAutonomixMessage> EffectiveHistory = ConversationHistory;
+	int32 HistoryTokens = FAutonomixTokenCounter::EstimateTokens(EffectiveHistory);
+	int32 TotalTokens = SystemTokens + HistoryTokens + ToolTokens + OverheadTokens;
+
+	if (TotalTokens > ContextWindow)
+	{
+		UE_LOG(LogAutonomix, Warning, TEXT("OpenAICompatClient: Estimated total tokens %d exceeds context window %d. Truncating history."), TotalTokens, ContextWindow);
+		// Truncate history from the beginning until it fits
+		while (EffectiveHistory.Num() > 1 && TotalTokens > ContextWindow)
+		{
+			EffectiveHistory.RemoveAt(0);
+			HistoryTokens = FAutonomixTokenCounter::EstimateTokens(EffectiveHistory);
+			TotalTokens = SystemTokens + HistoryTokens + ToolTokens + OverheadTokens;
+		}
+		UE_LOG(LogAutonomix, Log, TEXT("OpenAICompatClient: After truncation, history has %d messages, total tokens %d."), EffectiveHistory.Num(), TotalTokens);
+	}
+
 	// ---- API type selection ----
 	// Responses API (/v1/responses): official OpenAI only (GPT-5.x, GPT-4.1, o-series).
 	// Azure, Ollama, LMStudio, Custom do NOT support the Responses API.
@@ -203,7 +227,7 @@ void FAutonomixOpenAICompatClient::SendMessage(
 	                               Provider == EAutonomixProvider::Custom);
 	bUseResponsesAPI = (Provider == EAutonomixProvider::OpenAI) && !bIsAzureRequest && !bIsLocalProvider;
 
-	TSharedPtr<FJsonObject> Body = BuildRequestBody(ConversationHistory, SystemPrompt, ToolSchemas);
+	TSharedPtr<FJsonObject> Body = BuildRequestBody(EffectiveHistory, SystemPrompt, ToolSchemas);
 	FString BodyString;
 	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&BodyString);
 	FJsonSerializer::Serialize(Body.ToSharedRef(), Writer);

--- a/Source/AutonomixLLM/Private/AutonomixTokenCounter.cpp
+++ b/Source/AutonomixLLM/Private/AutonomixTokenCounter.cpp
@@ -55,6 +55,16 @@ int32 FAutonomixTokenCounter::EstimateTokens(const TArray<TSharedPtr<FJsonValue>
 	return EstimateTokens(Serialized);
 }
 
+int32 FAutonomixTokenCounter::EstimateTokens(const TArray<TSharedPtr<FJsonObject>>& JsonArray)
+{
+	int32 Total = 0;
+	for (const TSharedPtr<FJsonObject>& Obj : JsonArray)
+	{
+		Total += EstimateTokens(Obj);
+	}
+	return Total;
+}
+
 int32 FAutonomixTokenCounter::GetContextWindowTokens(bool bExtended)
 {
 	// Provider-aware context window lookup.

--- a/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
+++ b/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
@@ -12,7 +12,7 @@
  * This is intentionally simple — for pre-flight context budget checks,
  * not billing-accurate counting.
  */
-class FAutonomixTokenCounter
+class AUTONOMIXLLM_API FAutonomixTokenCounter
 {
 public:
 	/** Approximate tokens for a plain text string (~4 chars per token) */

--- a/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
+++ b/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
@@ -12,7 +12,7 @@
  * This is intentionally simple — for pre-flight context budget checks,
  * not billing-accurate counting.
  */
-class AUTONOMIXLLM_API FAutonomixTokenCounter
+class FAutonomixTokenCounter
 {
 public:
 	/** Approximate tokens for a plain text string (~4 chars per token) */

--- a/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
+++ b/Source/AutonomixLLM/Public/AutonomixTokenCounter.h
@@ -27,6 +27,9 @@ public:
 	/** Approximate tokens for a JSON value array (serializes then counts) */
 	static int32 EstimateTokens(const TArray<TSharedPtr<FJsonValue>>& JsonArray);
 
+	/** Approximate tokens for a JSON object array (serializes then counts) */
+	static int32 EstimateTokens(const TArray<TSharedPtr<FJsonObject>>& JsonArray);
+
 	/** Get the context window size in tokens for the given setting */
 	static int32 GetContextWindowTokens(bool bExtended = false);
 


### PR DESCRIPTION
…neInit" for the AutonomixActions module.

Why: Ensures editor subsystems (like FEdGraphUtilities) are initialized before the module tries to register tool executors.

Added T3D validation in AutonomixBlueprintActions.cpp ExecuteInjectNodesT3D: Check for "Begin Object" marker in T3D string.
Call MarkBlueprintAsModified after successful injection to ensure changes are saved.

Added pre-flight token estimation in AutonomixOpenAICompatClient.cpp: Estimates total tokens (system prompt + history + tools + overhead). Truncates conversation history from the beginning if total exceeds context window. Added EstimateTokens overload for TArray<TSharedPtr<FJsonObject>> in AutonomixTokenCounter.