### PR TITLE
Fix: ensure LLM output starts in a new message block by passing message role to UI update delegate

### DIFF
--- a/Source/AutonomixUI/Private/AutonomixChatSession.cpp
+++ b/Source/AutonomixUI/Private/AutonomixChatSession.cpp
@@ -189,7 +189,7 @@ void FAutonomixChatSession::ProcessToolCallQueue()
 			{
 				ResultToAppend = FString::Printf(TEXT("✅ %s"), *ResultContent);
 			}
-			OnMessageUpdated.Broadcast(ToolMsg.MessageId, ResultToAppend);
+			OnMessageUpdated.Broadcast(ToolMsg.MessageId, ResultToAppend, EAutonomixMessageRole::Assistant);
 		}
 	}
 
@@ -753,7 +753,7 @@ FString FAutonomixChatSession::ExecuteToolCall(const FAutonomixToolCall& ToolCal
 
 void FAutonomixChatSession::OnStreamingText(const FGuid& MessageId, const FString& DeltaText)
 {
-	OnMessageUpdated.Broadcast(MessageId, DeltaText);
+	OnMessageUpdated.Broadcast(MessageId, DeltaText, EAutonomixMessageRole::Assistant);
 }
 
 void FAutonomixChatSession::OnToolCallReceived(const FAutonomixToolCall& ToolCall)

--- a/Source/AutonomixUI/Private/Widgets/SAutonomixMainPanel.cpp
+++ b/Source/AutonomixUI/Private/Widgets/SAutonomixMainPanel.cpp
@@ -2983,7 +2983,7 @@ void SAutonomixMainPanel::OnMessageAdded(const FAutonomixMessage& Message)
     SaveTabsToDisk();
 }
 
-void SAutonomixMainPanel::OnMessageUpdated(const FGuid& MessageId, const FString& NewContent)
+void SAutonomixMainPanel::OnMessageUpdated(const FGuid& MessageId, const FString& NewContent, EAutonomixMessageRole Role)
 {
     if (NewContent.TrimStartAndEnd().IsEmpty())
     {
@@ -2992,7 +2992,7 @@ void SAutonomixMainPanel::OnMessageUpdated(const FGuid& MessageId, const FString
 
     if (ChatView.IsValid())
     {
-        ChatView->UpdateStreamingMessage(MessageId, NewContent);
+        ChatView->UpdateStreamingMessage(MessageId, NewContent, Role);
     }
 }
 

--- a/Source/AutonomixUI/Public/AutonomixChatSession.h
+++ b/Source/AutonomixUI/Public/AutonomixChatSession.h
@@ -26,7 +26,7 @@ DECLARE_MULTICAST_DELEGATE_OneParam(FOnToolRequiresApproval, const FAutonomixAct
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnAgentFinished, const FString& /*Reason*/);
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnTokenUsageUpdated, const FAutonomixTokenUsage& /*Usage*/);
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnMessageAdded, const FAutonomixMessage& /*Message*/);
-DECLARE_MULTICAST_DELEGATE_TwoParams(FOnMessageUpdated, const FGuid& /*MessageId*/, const FString& /*DeltaText*/);
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnMessageUpdated, const FGuid& /*MessageId*/, const FString& /*DeltaText*/, EAutonomixMessageRole /*Role*/);
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnStatusUpdated, const FString& /*StatusText*/); // For progress overlay
 DECLARE_MULTICAST_DELEGATE(FOnSessionCompletedContextManagement); // Trigger to resume after context condense
 

--- a/Source/AutonomixUI/Public/Widgets/SAutonomixMainPanel.h
+++ b/Source/AutonomixUI/Public/Widgets/SAutonomixMainPanel.h
@@ -284,7 +284,7 @@ private:
 
     // ---- Delegates from ChatSession ----
     void OnMessageAdded(const FAutonomixMessage& Message);
-    void OnMessageUpdated(const FGuid& MessageId, const FString& DeltaText);
+    void OnMessageUpdated(const FGuid& MessageId, const FString& DeltaText, EAutonomixMessageRole Role);
     void OnStatusUpdated(const FString& StatusText);
     void OnAgentFinished(const FString& Reason);
     void OnToolRequiresApproval(const FAutonomixActionPlan& Plan);


### PR DESCRIPTION
Fixed issue with Autonomix output being appended to the user input block ("You") rather than showing up under its own message block.