### PR TITLE
fix: move live project context out of the cached prompt prefix

### DIFF
--- a/Source/AutonomixUI/Private/Widgets/SAutonomixMainPanel.cpp
+++ b/Source/AutonomixUI/Private/Widgets/SAutonomixMainPanel.cpp
@@ -2255,7 +2255,7 @@ FString SAutonomixMainPanel::BuildSystemPrompt() const
     if (FFileHelper::LoadFileToString(CustomPrompt, *TemplatePath) && !CustomPrompt.IsEmpty())
     {
         // Replace {PROJECT_CONTEXT} placeholder — use empty string here since project context is in the dynamic section
-        CustomPrompt = CustomPrompt.Replace(TEXT("{PROJECT_CONTEXT}"), *ProjectContext);
+        CustomPrompt = CustomPrompt.Replace(TEXT("{PROJECT_CONTEXT}"), TEXT(""));
         SystemPrompt += TEXT("\n\n====\n\nCUSTOM INSTRUCTIONS\n\n") + CustomPrompt;
     }
 


### PR DESCRIPTION
## Problem

`BuildSystemPrompt()` in `Source/AutonomixUI/Private/Widgets/SAutonomixMainPanel.cpp` (line 2258) substitutes the live `ProjectContext` into the `{PROJECT_CONTEXT}` placeholder of the custom instructions block. That block is appended to `SystemPrompt` **before** the `===AUTONOMIX_DYNAMIC_SECTION===` marker (line 2263), i.e. inside the static prefix.

In `AutonomixClaudeClient.cpp` (lines 207-222) the system prompt is split on that marker, and only the static prefix (everything before the marker) is sent with `cache_control: { type: "ephemeral" }`. `ProjectContext` carries per-iteration asset/file/level counts that change on virtually every turn of the agentic loop, so putting it in the cached prefix changes the cached bytes each call and invalidates the cache write from the previous turn — the prefix is never actually reused.

The same `ProjectContext` is already added to the dynamic (post-marker, uncached) section at line 2267, so it is currently double-injected. The pre-marker copy is the bug. The existing comment on line 2257 ("use empty string here since project context is in the dynamic section") shows this was the original intent.

## Fix

Replace the `{PROJECT_CONTEXT}` placeholder with an empty string instead of `*ProjectContext`, so the static custom-instructions block no longer carries volatile data. The model still receives the full project context — it just arrives via the dynamic section after the cache breakpoint, exactly as the README describes (see the static/dynamic split documented around lines 60 and 98). One-line, pure-ordering change with no behavioral difference in what the model sees.

## Testing

I was not able to build or run this here — it requires Unreal Engine and a host `.uproject`, which I don't have set up. The change is intentionally a single-line move so it can be reviewed by reading: the placeholder substitution that previously injected `ProjectContext` into the cached prefix now resolves to empty, and the unchanged line 2267 continues to supply the same context in the dynamic block.